### PR TITLE
Fix manifest generation error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,27 +28,15 @@ jobs:
   
   manifest-conformace:
     runs-on: ubuntu-latest
+    container: openpolicyagent/conftest:latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Helm
         uses: azure/setup-helm@v3
 
-      - name: generate default manifest
+      - name: Validate Kubernetes policy
         run: |
-          helm template jenkins ./charts/ --debug -n jenkins -f test/default-registry/values.yaml > default-registry.yaml
-          helm template jenkins ./charts/ --debug -n jenkins -f test/override-registry/values.yaml > override-registry.yaml
-
-      - name: validate default-registry.yaml
-        uses: instrumenta/conftest-action@master
-        with:
-          files:  default-registry.yaml
-          policy: test/default-registry/
-
-      - name: validate override-registry.yaml
-        uses: instrumenta/conftest-action@master
-        with:
-          files:  override-registry.yaml
-          policy: test/override-registry/
+          OUTPUT=github make conftest 
 
 
   build-jenkins:
@@ -88,7 +76,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: init-variable
+    needs: [init-variable, manifest-conformace]
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,12 +25,37 @@ jobs:
         id: init_variable
         run: |
           echo container_tag=$(git describe --tags --abbrev=8) >> $GITHUB_OUTPUT
+  
+  manifest-conformace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: generate default manifest
+        run: |
+          helm template jenkins ./charts/ --debug -n jenkins -f test/default-registry/values.yaml > default-registry.yaml
+          helm template jenkins ./charts/ --debug -n jenkins -f test/override-registry/values.yaml > override-registry.yaml
+
+      - name: validate default-registry.yaml
+        uses: instrumenta/conftest-action@master
+        with:
+          files:  default-registry.yaml
+          policy: test/default-registry/
+
+      - name: validate override-registry.yaml
+        uses: instrumenta/conftest-action@master
+        with:
+          files:  override-registry.yaml
+          policy: test/override-registry/
+
 
   build-jenkins:
     permissions:
       contents: read
       packages: write
-    needs: init-variable
+    needs: [init-variable, manifest-conformace]
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,8 +189,10 @@ jobs:
       - name: init variables
         id: step-variable
         run: |
+          export "runtime=$([ ${{ matrix.runtime }} == podman ] && (echo -podman))"
           export "jdkVersion=$([ ${{ matrix.version }} == 1.8.0 ] && (echo -jdk1.8) || (echo -jdk11) )"
-          echo "suffix=${jdkVersion}$([ ${{ matrix.runtime }} == podman ] && (echo -podman))" >> $GITHUB_OUTPUT
+          echo "runtime=${runtime}" >> $GITHUB_OUTPUT
+          echo "suffix=${jdkVersion}${runtime}" >> $GITHUB_OUTPUT
       - name: use setup-buildx-action
         uses: docker/setup-buildx-action@v2
       - name: build jenkins agent with maven
@@ -207,7 +209,7 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/jenkins-agent-maven:latest${{ steps.step-variable.outputs.suffix }}
           build-args: |
             REGISTRY_REPO=${{ secrets.DOCKER_USERNAME }}
-            RUNTIME=${{ steps.step-variable.outputs.suffix }}
+            RUNTIME=${{ steps.step-variable.outputs.runtime }}
             JAVA_VERSION=${{ matrix.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,13 +28,12 @@ jobs:
   
   manifest-conformace:
     runs-on: ubuntu-latest
-    container: openpolicyagent/conftest:latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Helm
         uses: azure/setup-helm@v3
 
-      - name: Validate Kubernetes policy
+      - name: Validate Helm Policy
         run: |
           OUTPUT=github make conftest 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,8 +177,8 @@ jobs:
       - name: init variables
         id: step-variable
         run: |
-          echo "suffix=$([ ${{ matrix.version }} == 1.8.0 ] && (echo -jdk1.8) || (echo -jdk11) )"
-          echo "suffix=${suffix}$([ ${{ matrix.runtime }} == podman ] && (echo -podman))" >> $GITHUB_OUTPUT
+          export "jdkVersion=$([ ${{ matrix.version }} == 1.8.0 ] && (echo -jdk1.8) || (echo -jdk11) )"
+          echo "suffix=${jdkVersion}$([ ${{ matrix.runtime }} == podman ] && (echo -podman))" >> $GITHUB_OUTPUT
       - name: use setup-buildx-action
         uses: docker/setup-buildx-action@v2
       - name: build jenkins agent with maven

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,25 @@ e2e-test:
 .PHONY: local-e2e-test
 local-e2e-test:
 	KIND_IMAGE="release-ci.daocloud.io/kpanda/kindest-node:v1.26.0" ./hack/e2e-test.sh $(VERSION)
+
+.PHONY: install-conftest
+install-conftest:
+	./hack/install/conftest.sh
+
+.PHONY: conftest
+conftest: install-conftest
+	helm template  jenkins ./charts/ --debug -n jenkins -f test/default-registry/values.yaml > tmp.yaml
+	conftest test --policy test/default-registry/deny.rego tmp.yaml
+
+	helm template  jenkins ./charts/ --debug -n jenkins -f test/override-registry/values.yaml > tmp.yaml
+	conftest test --policy test/override-registry/deny.rego tmp.yaml
+
+	rm tmp.yaml
+
+.PHONY: install-opa
+install-opa:
+	./hack/install/opa.sh
+
+.PHONY: opa-test
+opa-test: install-opa
+	opa test test/default-registry/ -v

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ INSTALLATION_NAME ?= "jenkins"
 DEPLOY_ENV ?= ""
 VERSION ?= ""
 FILENAME := ""
+OUTPUT ?= "stdout"
 ifeq ($(VERSION), "")
     LATEST_TAG=$(shell  git describe --tags --abbrev=8)
     ifeq ($(LATEST_TAG),)
@@ -53,10 +54,10 @@ install-conftest:
 .PHONY: conftest
 conftest: install-conftest
 	helm template  jenkins ./charts/ --debug -n jenkins -f test/default-registry/values.yaml > tmp.yaml
-	conftest test --policy test/default-registry/deny.rego tmp.yaml
+	conftest test -o $(OUTPUT) --policy test/default-registry/deny.rego tmp.yaml
 
 	helm template  jenkins ./charts/ --debug -n jenkins -f test/override-registry/values.yaml > tmp.yaml
-	conftest test --policy test/override-registry/deny.rego tmp.yaml
+	conftest test -o $(OUTPUT) --policy test/override-registry/deny.rego tmp.yaml
 
 	rm tmp.yaml
 

--- a/charts/.relok8s-images.yaml
+++ b/charts/.relok8s-images.yaml
@@ -1,5 +1,4 @@
 - "{{ .image.registry }}/{{ .Master.Image }}:{{ .Master.ImageTag }}"
-- "{{ .image.registry }}/{{ .Master.Image }}:{{ .Master.ImageTag }}"
 - "{{ .image.registry }}/{{ .Agent.Image }}:{{ .Agent.ImageTag }}"
 - "{{ .image.registry }}/{{ .Agent.Builder.Base.Image }}:{{ .Agent.Builder.Base.Tag }}-podman"
 - "{{ .image.registry }}/{{ .Agent.Builder.Base.Image }}:{{ .Agent.Builder.Base.Tag }}"

--- a/charts/.relok8s-images.yaml
+++ b/charts/.relok8s-images.yaml
@@ -13,4 +13,4 @@
 - "{{ .image.registry }}/{{ .Agent.Builder.Python.Image }}:{{ .Agent.Builder.Python.Tag }}-podman"
 - "{{ .image.registry }}/{{ .Agent.Builder.Python.Image }}:{{ .Agent.Builder.Python.Tag }}"
 - "{{ .trace.image.registry }}/{{ .trace.image.repository }}:{{ .trace.image.tag }}"
-- "{{ .image.registry }}/{{ .eventProxy.image.repository }}:{{ .eventProxy.image.tag }}"
+- "{{ .eventProxy.image.registry }}/{{ .eventProxy.image.repository }}:{{ .eventProxy.image.tag }}"

--- a/charts/templates/_commons.tpl
+++ b/charts/templates/_commons.tpl
@@ -24,3 +24,53 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Return the proper image name for the `image.registry/repository/tag` style values
+eg. trace, eventProxy
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name for the `Image/ImageTag` style values
+eg. Master, Agent, Agent.Builder.Base
+{{ include "jenkins.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global "root" .Values.image ) }}
+*/}}
+{{- define "jenkins.images.image" -}}
+{{- $registryName := .root.registry -}}
+{{- $repositoryName := .imageRoot.Image -}}
+{{- $tag := .imageRoot.ImageTag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Shortcut to return image for builders
+{{ include "builder.image" ( dict "builder" .Values.Agent.Builder.Base "root" .) }}
+*/}}
+{{- define "builder.image" }}
+  {{- include "jenkins.images.image" (dict "imageRoot" .builder "global" .root.Values.global "root" .root.Values.image) -}}
+{{- end -}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -65,20 +65,8 @@ https://github.com/helm/charts/issues/5167#issuecomment-619137759
     {{- end -}}
 {{- end -}}
 
-{{- define "jenkins.image" -}}
-    {{- $jenkinsRegistryName := .Values.image.registry -}}
-    {{- $repositoryName := .Values.Master.Image -}}
-    {{- printf "%s/%s:%s" $jenkinsRegistryName $repositoryName .Values.Master.ImageTag -}}
-{{- end -}}
-
-{{- define "jenkins-agent.image.registry" -}}
-    {{- $jenkinsRegistryName := .Values.image.registry -}}
-    {{- printf "%s" $jenkinsRegistryName -}}
-{{- end -}}
-
-{{- define "jenkins-agent.jnlp.image" -}}
-    {{- $registry := include "jenkins-agent.image.registry" . -}}
-    {{- printf "%s/%s:%s" $registry .Values.Agent.Image .Values.Agent.ImageTag -}}
+{{- define "jenkins-agent.jnlp.image" }}
+    {{- include "jenkins.images.image" ( dict "imageRoot" .Values.Agent "global" .Values.global "root" .Values.image ) }}
 {{- end -}}
 
 {{- define "jenkins-agent.volume" -}}

--- a/charts/templates/jenkins-casc-config.yml
+++ b/charts/templates/jenkins-casc-config.yml
@@ -30,7 +30,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "base"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.Base.Image }}:{{ .Values.Agent.Builder.Base.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{ include "builder.image" (dict "builder" .Values.Agent.Builder.Base "root" .) -}}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -89,7 +89,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "nodejs"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.NodeJs16.Image }}:{{ .Values.Agent.Builder.NodeJs16.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{ include "builder.image" ( dict "builder" .Values.Agent.Builder.NodeJs16 "root" .) -}}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -154,7 +154,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "maven"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.Maven.Image }}:{{ .Values.Agent.Builder.Maven.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{ include "builder.image" ( dict "builder" .Values.Agent.Builder.Maven "root" .) -}}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -226,8 +226,7 @@ data:
                 inheritFrom: "maven"
                 containers:
                 - name: "maven"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.Mavenjdk11.Image }}:{{ .Values.Agent.Builder.Mavenjdk11.Tag }}{{ template "jenkins.agent.variant" . }}"
-
+                  image: "{{ include "builder.image" ( dict "builder" .Values.Agent.Builder.Mavenjdk11 "root" .) -}}"
               - name: "go"
                 namespace: "{{ default .Release.Namespace .Values.Agent.WorkerNamespace }}"
                 label: "go"
@@ -235,7 +234,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "go"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.Golang.Image }}:{{ .Values.Agent.Builder.Golang.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{ include "builder.image" ( dict "builder" .Values.Agent.Builder.Golang "root" .) -}}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true
@@ -297,7 +296,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "python"
-                  image: "{{ template "jenkins-agent.image.registry" . }}/{{ .Values.Agent.Builder.Python.Image }}:{{ .Values.Agent.Builder.Python.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{- include "builder.image" ( dict "builder" .Values.Agent.Builder.Python "root" .) }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true

--- a/charts/templates/jenkins-master-deployment.yaml
+++ b/charts/templates/jenkins-master-deployment.yaml
@@ -57,7 +57,7 @@ spec:
 {{- end }}
       initContainers:
         - name: "copy-default-config"
-          image: {{ template "jenkins.image" . }}
+          image: {{ include "jenkins.images.image" (dict "imageRoot" .Values.Master "global" .Values.global "root" .Values.image ) }}
           imagePullPolicy: {{ template "jenkins.image.pullPolicy" . }}
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           env:
@@ -79,37 +79,30 @@ spec:
           resources:
 {{ toYaml .Values.Master.resources | indent 12 }}
           volumeMounts:
-            -
-              mountPath: /var/jenkins_home
+            - mountPath: /var/jenkins_home
               name: jenkins-home
-            -
-              mountPath: /var/jenkins_config
+            - mountPath: /var/jenkins_config
               name: jenkins-config
             {{- if .Values.Master.CredentialsXmlSecret }}
-            -
-              mountPath: /var/jenkins_credentials
+            - mountPath: /var/jenkins_credentials
               name: jenkins-credentials
               readOnly: true
             {{- end }}
             {{- if .Values.Master.SecretsFilesSecret }}
-            -
-              mountPath: /var/jenkins_secrets
+            - mountPath: /var/jenkins_secrets
               name: jenkins-secrets
               readOnly: true
             {{- end }}
             {{- if .Values.Master.Jobs }}
-            -
-              mountPath: /var/jenkins_jobs
+            - mountPath: /var/jenkins_jobs
               name: jenkins-jobs
               readOnly: true
             {{- end }}
-            -
-              mountPath: /usr/share/jenkins/ref/secrets/
+            - mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
-
         {{- if .Values.trace.enabled }}
         - name: opentelemetry-auto-instrumentation
-          image: "{{ .Values.trace.image.registry }}/{{ .Values.trace.image.repository }}:{{ .Values.trace.image.tag }}"
+          image: "{{ include "common.images.image" (dict "imageRoot" .Values.trace.image "global" .Values.global ) -}}"
           command:
             - sh
             - '-c'
@@ -118,10 +111,9 @@ spec:
             - name: opentelemetry-auto-instrumentation
               mountPath: /otel-auto-instrumentation
         {{- end }}
-      
       containers:
         - name: {{ template "jenkins.fullname" . }}
-          image: {{ template "jenkins.image" . }}
+          image: "{{ include "jenkins.images.image" (dict "imageRoot" .Values.Master "global" .Values.global "root" .Values.image ) }}"
           imagePullPolicy: {{ template "jenkins.image.pullPolicy" . }}
           {{- if .Values.Master.UseSecurity }}
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
@@ -157,7 +149,6 @@ spec:
             - name: OTEL_TRACES_SAMPLER
               value: always_on
             - name: TZ
-              #{{/*              value: Asia/Shanghai*/}}
               value: "{{ default "Asia/Shanghai" .Values.Master.TZ | replace "\n" " "}}"
             - name: JAVA_TOOL_OPTIONS
               value: {{ template "jenkins.master.javaOpts" . }}
@@ -246,7 +237,7 @@ spec:
               readOnly: false
         {{- if .Values.eventProxy.enabled }}
         - name: event-proxy
-          image: {{ template "jenkins.event-proxy.image" . }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.eventProxy.image "global" .Values.global ) }}
           imagePullPolicy: {{ template "jenkins.event-proxy.pullPolicy" . }}
           command:
             - /bin/event-proxy

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,13 +10,6 @@ plugins:
   eventDispatcher:
     receiver: ""
 
-trace:
-  enabled: false
-  image:
-    registry: ghcr.io
-    repository: open-telemetry/opentelemetry-operator/autoinstrumentation-java
-    tag: 1.17.0
-
 Master:
   StatefulSet:
     Enabled: false
@@ -350,25 +343,24 @@ Agent:
   # jenkins-agent: v1
 
   Builder:
-    # Registry: "docker.io"
     Base:
       Image: amambadev/jenkins-agent-base
-      Tag: latest
+      ImageTag: latest
     NodeJs16:
       Image: amambadev/jenkins-agent-nodejs
-      Tag: latest
+      ImageTag: latest
     Maven:
       Image: amambadev/jenkins-agent-maven
-      Tag: latest-jdk1.8
+      ImageTag: latest-jdk1.8
     Mavenjdk11:
       Image: amambadev/jenkins-agent-maven
-      Tag: latest-jdk11
+      ImageTag: latest-jdk11
     Golang:
       Image: amambadev/jenkins-agent-go
-      Tag: latest
+      ImageTag: latest
     Python:
       Image: amambadev/jenkins-agent-python
-      Tag: latest
+      ImageTag: latest
     ContainerRuntime: podman # Available values: docker, podman
 
 Persistence:
@@ -425,6 +417,7 @@ prometheus:
 eventProxy:
   enabled: false
   image:
+    registry: release.daocloud.io
     repository: amamba/amamba-event-proxy
     tag: "v0.18.0-alpha.0"
   imagePullPolicy: IfNotPresent
@@ -452,3 +445,9 @@ eventProxy:
     #    cpu: 200m
     #    memory: 200Mi
 
+trace:
+  enabled: false
+  image:
+    registry: ghcr.io
+    repository: open-telemetry/opentelemetry-operator/autoinstrumentation-java
+    tag: 1.17.0

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -13,7 +13,7 @@ plugins:
 trace:
   enabled: false
   image:
-    registry: ghcr.m.daocloud.io
+    registry: ghcr.io
     repository: open-telemetry/opentelemetry-operator/autoinstrumentation-java
     tag: 1.17.0
 
@@ -26,7 +26,7 @@ Master:
     # Name of the Kubernetes scheduler to use
     SchedulerName: ""
   Name: jenkins-master
-  Image: "amamba/jenkins"
+  Image: "amambadev/jenkins"
   ImageTag: "latest-2.413"
   ImagePullPolicy: "IfNotPresent"
   ImagePullSecret: ""

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -14,7 +14,7 @@ TARGET_NS=${3:-"jenkins"}
 LOCAL_RELEASE_NAME=jenkins
 
 echo "Rendering values.yaml with VERSION=${VERSION}"
-envsubst -i config/e2e.yaml -o /tmp/e2e.yaml
+envsubst < config/e2e.yaml > /tmp/e2e.yaml
 
 values="-f /tmp/e2e.yaml"
 

--- a/hack/install/conftest.sh
+++ b/hack/install/conftest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+which conftest > /dev/null 2>&1 && exit 0
+
+LATEST_VERSION=$(wget -O - "https://api.github.com/repos/open-policy-agent/conftest/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+wget "https://github.com/open-policy-agent/conftest/releases/download/v${LATEST_VERSION}/conftest_${LATEST_VERSION}_Linux_x86_64.tar.gz"
+tar xzf conftest_${LATEST_VERSION}_Linux_x86_64.tar.gz
+sudo mv conftest /usr/local/bin

--- a/hack/install/envsubst.sh
+++ b/hack/install/envsubst.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+which envsubst > /dev/null 2>&1 && exit 0
+
 curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-`uname -s`-`uname -m` -o envsubst
 chmod +x envsubst
 sudo mv envsubst /usr/local/bin

--- a/hack/install/opa.sh
+++ b/hack/install/opa.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+which opa > /dev/null 2>&1 && exit 0
+
+curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+chmod 755 opa
+sudo mv opa /usr/local/bin

--- a/test/default-registry/base_test.rego
+++ b/test/default-registry/base_test.rego
@@ -1,0 +1,88 @@
+package main
+
+empty(value) {
+	count(value) == 0
+}
+
+no_violations {
+	empty(deny)
+}
+
+test_casc_with_valid_image {
+	input := {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "jenkins-casc-config"},
+		"data": {"jenkins.yaml": "jenkins:\n  clouds:\n    - kubernetes:\n        templates:\n          - name: \"base\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"base\"\n              image: \"docker.io/amambadev/jenkins-agent-base:latest\"\n            - name: \"jnlp\"\n              image: \"docker.io/jenkins/inbound-agent:4.10-2\"\n          - name: \"nodejs\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"nodejs\"\n              image: \"docker.io/amambadev/jenkins-agent-nodejs:latest\"\n            - name: \"jnlp\"\n              image: \"docker.io/jenkins/inbound-agent:4.10-2\"\n"},
+	}
+	no_violations with input as input
+}
+
+test_casc_with_invalid_base {
+	input := {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "jenkins-casc-config"},
+		"data": {"jenkins.yaml": "jenkins:\n  clouds:\n    - kubernetes:\n        templates:\n          - name: \"base\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"base\"\n              image: \"base:latest\"\n            - name: \"jnlp\"\n              image: \"docker.io/jenkins/inbound-agent:4.10-2\"\n          - name: \"nodejs\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"nodejs\"\n              image: \"docker.io/amambadev/jenkins-agent-nodejs:latest\"\n            - name: \"jnlp\"\n              image: \"docker.io/jenkins/inbound-agent:4.10-2\"\n"},
+	}
+	deny["'base' should not use image: 'base:latest'"] with input as input
+}
+
+test_casc_with_invalid_jnlp {
+	input := {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "jenkins-casc-config"},
+		"data": {"jenkins.yaml": "jenkins:\n  clouds:\n    - kubernetes:\n        templates:\n          - name: \"base\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"base\"\n              image: \"docker.io/amambadev/jenkins-agent-base:latest\"\n            - name: \"jnlp\"\n              image: \"inbound-agent:4.10-2\"\n          - name: \"nodejs\"\n            namespace: \"jenkins\"\n            containers:\n            - name: \"nodejs\"\n              image: \"docker.io/amambadev/jenkins-agent-nodejs:latest\"\n            - name: \"jnlp\"\n              image: \"docker.io/jenkins/inbound-agent:4.10-2\"\n"},
+	}
+	deny["'jnlp' should not use image: 'inbound-agent:4.10-2'"] with input as input
+}
+
+test_default_deployments_image {
+	input := {
+		"kind": "Deployment",
+		"metadata": {"name": "jenkins"},
+		"spec": {"template": {"spec": {
+			"initContainers": [
+				{
+					"name": "copy-default-config",
+					"image": "docker.io/amambadev/jenkins:latest-2.413",
+				},
+				{
+					"name": "opentelemetry-auto-instrumentation",
+					"image": "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.17.0",
+				},
+			],
+			"containers": [
+				{
+					"name": "jenkins",
+					"image": "docker.io/amambadev/jenkins:latest-2.413",
+				},
+				{
+					"name": "event-proxy",
+					"image": "release.daocloud.io/amamba/amamba-event-proxy:v0.18.0-alpha.0",
+				},
+			],
+		}}},
+	}
+	no_violations with input as input
+}
+
+test_cotainers_missing {
+	input := {
+		"kind": "Deployment",
+		"metadata": {"name": "jenkins"},
+		"spec": {"template": {"spec": {
+			"initContainers": [{
+				"name": "copy-default-config",
+				"image": "docker.io/amambadev/jenkins:latest-2.413",
+			}],
+			"containers": [{
+				"name": "jenkins",
+				"image": "docker.io/amambadev/jenkins:latest-2.413",
+			}],
+		}}},
+	}
+	deny["'opentelemetry-auto-instrumentation' is not enabled"] with input as input
+	deny["'event-proxy' is not enabled"] with input as input
+}

--- a/test/default-registry/deny.rego
+++ b/test/default-registry/deny.rego
@@ -1,0 +1,96 @@
+package main
+
+import future.keywords.every
+import future.keywords.if
+
+deny[msg] {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.initContainers[_]
+	not is_copy_default_config_image(container)
+	not is_instrumentation_image(container)
+
+	msg := sprintf("%v should not use image: '%v'", [container.name, container.image])
+}
+
+is_copy_default_config_image(container) if {
+	container.name == "copy-default-config"
+	container.image == "docker.io/amambadev/jenkins:latest-2.413"
+}
+
+is_instrumentation_image(container) if {
+	container.name == "opentelemetry-auto-instrumentation"
+	container.image == "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.17.0"
+}
+
+deny[msg] {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	not is_jenkins_image(container)
+	not is_event_proxy_image(container)
+
+	msg := sprintf("%v should not use image: '%v'", [container.name, container.image])
+}
+
+is_jenkins_image(container) if {
+	container.name == "jenkins"
+	container.image == "docker.io/amambadev/jenkins:latest-2.413"
+}
+
+is_event_proxy_image(container) if {
+	container.name == "event-proxy"
+	container.image == "release.daocloud.io/amamba/amamba-event-proxy:v0.18.0-alpha.0"
+}
+
+deny[msg] {
+	input.kind == "Deployment"
+	not has_container(input.spec.template.spec.containers, "event-proxy")
+
+	msg := "'event-proxy' is not enabled"
+}
+
+deny[msg] {
+	input.kind == "Deployment"
+	not has_container(input.spec.template.spec.initContainers, "opentelemetry-auto-instrumentation")
+
+	msg := "'opentelemetry-auto-instrumentation' is not enabled"
+}
+
+has_container(containers, name) if {
+	some i
+	containers[i].name == name
+}
+
+deny[msg] {
+	input.kind == "ConfigMap"
+	input.metadata.name == "jenkins-casc-config"
+
+	data1 := input.data["jenkins.yaml"]
+	obj := yaml.unmarshal(data1)
+	msg := find_unknown_images(obj.jenkins.clouds[_].kubernetes.templates[_].containers[_])
+}
+
+agents := {
+	"base": {"container": "base", "image": "docker.io/amambadev/jenkins-agent-base:latest"},
+	"maven": {"container": "maven", "image": "docker.io/amambadev/jenkins-agent-maven:latest-jdk1.8"},
+	"mavenjdk11": {"container": "maven", "image": "docker.io/amambadev/jenkins-agent-maven:latest-jdk11"},
+	"nodejs": {"container": "nodejs", "image": "docker.io/amambadev/jenkins-agent-nodejs:latest"},
+	"go": {"container": "go", "image": "docker.io/amambadev/jenkins-agent-go:latest"},
+	"python": {"container": "python", "image": "docker.io/amambadev/jenkins-agent-python:latest"},
+}
+
+is_jnlp_image(container) if {
+	container.name == "jnlp"
+	container.image == "docker.io/jenkins/inbound-agent:4.10-2"
+}
+
+is_agent_image(container) if {
+	some name
+	agents[name].container == container.name
+	agents[name].image == container.image
+}
+
+find_unknown_images(container) := msg if {
+	not is_jnlp_image(container)
+	not is_agent_image(container)
+	msg := sprintf("'%v' should not use image: '%v'", [container.name, container.image])
+}

--- a/test/default-registry/values.yaml
+++ b/test/default-registry/values.yaml
@@ -1,0 +1,5 @@
+trace:
+  enabled: true
+
+eventProxy:
+  enabled: true

--- a/test/override-registry/deny.rego
+++ b/test/override-registry/deny.rego
@@ -1,0 +1,29 @@
+package main
+
+deny[msg] {
+	input.kind == "Deployment"
+	image := input.spec.template.spec.containers[_].image
+	not startswith(image, "my-company.com/")
+
+	msg := sprintf("image '%v' doesn't come from my-company.com repository", [image])
+}
+
+deny[msg] {
+	input.kind == "Deployment"
+	image := input.spec.template.spec.initContainers[_].image
+	not startswith(image, "my-company.com/")
+
+	msg := sprintf("image '%v' doesn't come from my-company.com repository", [image])
+}
+
+deny[msg] {
+	input.kind == "ConfigMap"
+	input.metadata.name == "jenkins-casc-config"
+
+	data := input.data["jenkins.yaml"]
+	obj := yaml.unmarshal(data)
+	image := obj.jenkins.clouds[_].kubernetes.templates[_].containers[_].image
+	not startswith(image, "my-company.com/")
+
+	msg := sprintf("image '%v' doesn't come from my-company.com repository", [image])
+}

--- a/test/override-registry/values.yaml
+++ b/test/override-registry/values.yaml
@@ -1,0 +1,8 @@
+global:
+  imageRegistry: my-company.com
+
+trace:
+  enabled: true
+
+eventProxy:
+  enabled: true


### PR DESCRIPTION
- 修复了构建的maven镜像缺少`-jdk1.8`和`-jdk11`的后缀
- 修复了`global.imageRegistry`无法覆盖所有镜像的registry的问题，并增加了左移验证
- 修复了jenkins-master使用的默认registry是amamba而不是amambadev的问题
- 修复了event-proxy的默认registry不是 release.daocloud.io 的问题
- 左移了chart验证，增加了验证默认的registry和image 是正确的