### PR TITLE
fix: update casc if runtime changed

### DIFF
--- a/charts/templates/_commons.tpl
+++ b/charts/templates/_commons.tpl
@@ -72,5 +72,5 @@ Shortcut to return image for builders
 {{ include "builder.image" ( dict "builder" .Values.Agent.Builder.Base "root" .) }}
 */}}
 {{- define "builder.image" }}
-  {{- include "jenkins.images.image" (dict "imageRoot" .builder "global" .root.Values.global "root" .root.Values.image) -}}
+  {{- include "jenkins.images.image" (dict "imageRoot" .builder "global" .root.Values.global "root" .root.Values.image) -}}{{ template "jenkins.agent.variant" .root }}
 {{- end -}}

--- a/charts/values.schema.json
+++ b/charts/values.schema.json
@@ -2,7 +2,6 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "required": [
-        "Master",
         "image"
     ],
     "properties": {


### PR DESCRIPTION
修复了不会根据runtime（docker, containerd）的变化使用不同的镜像tag的问题