### PR TITLE
fix: default receiver url error

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -108,6 +108,26 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `prometheus.prometheusRule.alertRules` | Append these alert rules to prometheus rule     | `[]`                                                                                                 |
 
 
+### Event Dispatcher Config
+
+| Parameter                                    | Description                                       | Default                                                                                            |
+|----------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `plugins.eventDispatcher.receiver`           |                                                   | `""`                                                                                               |
+| `eventProxy.enabled`                         | enable eventProxy                                 | `false`                                                                                            |
+| `eventProxy.configMap.eventProxy.host`       | host of event receiver                            | `amamba-devops-server.amamba-system:80`                                                            |
+| `eventProxy.configMap.eventProxy.proto`      | proto of event receiver,must be 'http' or 'https' | `http`                                                                                             |
+| `eventProxy.configMap.eventProxy.webhookUrl` | url of event receiver                             | `/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins` |
+| `eventProxy.configMap.eventProxy.token`      | token to visit receiver                           | ``                                                                                                 |
+
+generic-event-plugin is a plugin of jenkins, it can send event(job/build) to a receiver(configuration by `eventDispatcher.Receiver` in CASC), and the receiver will handle the event. now we support two mode to send event to receiver:
+- direct mode: jenkins will send event to receiver directly.
+- proxy mode: jenkins will send event to a eventProxy, and the proxy will send event to receiver.
+
+parameters related to eventDispatcher:
+- if `eventProxy.enabled` is `true`, the `plugins.eventDispatcher.receiver` will be set to `http://localhost:9090/event`.
+- if `eventProxy.enabled` is `false`, and `plugins.eventDispatcher.receiver` is not empty, the `plugins.eventDispatcher.receiver` will be used.
+- if `eventProxy.enabled` is `false`, and `plugins.eventDispatcher.receiver` is empty, the default value is `http://amamba-devops-server.amamba-system:80/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins`.
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -96,7 +96,7 @@ https://github.com/helm/charts/issues/5167#issuecomment-619137759
 {{- end -}}
 
 {{- define "jenkins.event.receiver" -}}
-    {{- $defaultReceiver := "http://amamba-devops-server.%s:80/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins" -}}
+    {{- $defaultReceiver := "http://amamba-devops-server.amamba-system:80/apis/internel.amamba.io/devops/pipeline/v1alpha1/webhooks/jenkins" -}}
     {{- $sidecarReceiver := "http://localhost:9090/event" -}}
     {{- $target := "" -}}
     {{- if and .Values.eventProxy .Values.eventProxy.enabled -}}
@@ -105,7 +105,7 @@ https://github.com/helm/charts/issues/5167#issuecomment-619137759
         {{- if and .Values.plugins .Values.plugins.eventDispatcher .Values.plugins.eventDispatcher.receiver -}}
             {{- $target = .Values.plugins.eventDispatcher.receiver -}}
         {{- else -}}
-            {{- $target = printf $defaultReceiver .Release.Namespace -}}
+            {{- $target = $defaultReceiver -}}
         {{- end -}}
     {{- end -}}
     {{ print $target }}


### PR DESCRIPTION
fix if jenkins installed in different namespace , eventDispatcher  default recevier url error.


<img width="994" alt="image" src="https://github.com/amamba-io/jenkins-agent/assets/34639446/4759dceb-f176-4072-b019-0e7f36da0d35">
