### PR TITLE
fix: upgrade failed for a fixed node port

### DIFF
--- a/charts/templates/jenkins-master-svc.yaml
+++ b/charts/templates/jenkins-master-svc.yaml
@@ -17,9 +17,9 @@ spec:
     - port: {{.Values.Master.ServicePort}}
       name: http
       targetPort: 8080
-      {{if (not (empty (include "svc.nodePort" .) ))}}
+      {{- if (not (empty (include "svc.nodePort" .) ))}}
       nodePort: {{ include "svc.nodePort" . }}
-      {{end}}
+      {{- end}}
   selector:
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
   type: {{ include "svc.serviceType" . }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -66,7 +66,7 @@ Master:
     JenkinsHost: ""
   ServicePort: 80
   ServiceType: ClusterIP
-  NodePort: 31767
+  NodePort:
   ServiceAnnotations: {}
   Casc:
     # Maximum number of parallel pipelines


### PR DESCRIPTION
Do not use the fixed NodePort in case port conflicts.

```
yang@tim:~/workspace/jenkins-agent$ helm template jenkins ./charts/ -f charts/values.yaml --set Master.ServiceType=NodePort --set Master.NodePort=30080  | grep -C 10 NodePort
    chart: "jenkins-0.1.0"
    component: "jenkins-jenkins-master"
spec:
  ports:
    - port: 80
      name: http
      targetPort: 8080
      nodePort: 30080
  selector:
    component: "jenkins-jenkins-master"
  type: NodePort
---
# Source: jenkins/templates/jenkins-master-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: jenkins
  labels:
    heritage: "Helm"
    release: "jenkins"
    chart: "jenkins-0.1.0"
yang@tim:~/workspace/jenkins-agent$ helm template jenkins ./charts/ -f charts/values.yaml --set Master.ServiceType=NodePort   | grep -C 10 NodePort
    release: "jenkins"
    chart: "jenkins-0.1.0"
    component: "jenkins-jenkins-master"
spec:
  ports:
    - port: 80
      name: http
      targetPort: 8080
  selector:
    component: "jenkins-jenkins-master"
  type: NodePort
---
# Source: jenkins/templates/jenkins-master-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: jenkins
  labels:
    heritage: "Helm"
    release: "jenkins"
    chart: "jenkins-0.1.0"
```