### PR TITLE
chore: check agent tools after build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,6 +101,7 @@ jobs:
       packages: write
     needs: [init-variable, manifest-conformance]
     strategy:
+      fail-fast: false
       matrix:
         os: ["centos", "ubuntu"]
     runs-on: ubuntu-24.04
@@ -135,6 +136,13 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/jenkins-agent-base:latest${{ steps.step-variable.outputs.distribution }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check tools with docker
+        run: |
+          AGENT_IMAGE="${{ secrets.DOCKER_USERNAME }}/jenkins-agent-base:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.distribution }}"
+          echo "Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_base_tools.sh:/tmp/check_agent_base_tools.sh -e AGENT_IMAGE=$AGENT_IMAGE -i $AGENT_IMAGE /bin/bash -c "
+            ./tmp/check_agent_base_tools.sh
+          "
       - name: build jenkins agent with podman
         uses: docker/build-push-action@v6
         with:
@@ -153,6 +161,13 @@ jobs:
             DISTRIBUTION_SUFFIX=${{ steps.step-variable.outputs.distribution }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check tools with podman
+        run: |
+          AGENT_IMAGE="${{ secrets.DOCKER_USERNAME }}/jenkins-agent-base:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.distribution }}-podman"
+          echo "Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_base_tools.sh:/tmp/check_agent_base_tools.sh -e AGENT_IMAGE=$AGENT_IMAGE -i $AGENT_IMAGE /bin/bash -c "
+            ./tmp/check_agent_base_tools.sh
+          "
   build-deprected-agent-centos:
     needs: [build-jenkins-agent-base, init-variable]
     uses: ./.github/workflows/build_centos.yaml
@@ -163,6 +178,7 @@ jobs:
   build-agent-nodejs:
     needs: [build-jenkins-agent-base, init-variable]
     strategy:
+      fail-fast: false
       matrix:
         runtime: [docker, podman]
         version: [16.20.2, 18.20.4, 20.17.0]
@@ -208,9 +224,21 @@ jobs:
             DISTRIBUTION_SUFFIX=-${{ env.os }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check nodejs agent tools
+        run: |
+          SOFTWARE_MATRIX=nodejs-${{ matrix.version }}
+          AGENT_IMAGE=${{ secrets.DOCKER_USERNAME }}/jenkins-agent-nodejs:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.suffix }}
+          echo "Software Matrix Version: ${SOFTWARE_MATRIX}, Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_software_tools.sh:/tmp/check_agent_software_tools.sh \
+            -e AGENT_IMAGE=$AGENT_IMAGE \
+            -e SOFTWARE_MATRIX=${SOFTWARE_MATRIX} \
+            -i $AGENT_IMAGE /bin/bash -c "
+              ./tmp/check_agent_software_tools.sh
+            "
   build-agent-python:
     needs: [build-jenkins-agent-base, init-variable]
     strategy:
+      fail-fast: false
       matrix:
         runtime: [docker, podman]
         version: [3.8.19, 2.7.9, 3.10.9, 3.11.9]
@@ -256,9 +284,21 @@ jobs:
             DISTRIBUTION_SUFFIX=-${{ env.os }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check python agent tools
+        run: |
+          SOFTWARE_MATRIX=python-${{ matrix.version }}
+          AGENT_IMAGE=${{ secrets.DOCKER_USERNAME }}/jenkins-agent-python:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.suffix }}
+          echo "Software Matrix Version: ${SOFTWARE_MATRIX}, Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_software_tools.sh:/tmp/check_agent_software_tools.sh \
+            -e AGENT_IMAGE=$AGENT_IMAGE \
+            -e SOFTWARE_MATRIX=${SOFTWARE_MATRIX} \
+            -i $AGENT_IMAGE /bin/bash -c "
+              ./tmp/check_agent_software_tools.sh
+            "
   build-agent-golang:
     needs: [build-jenkins-agent-base, init-variable]
     strategy:
+      fail-fast: false
       matrix:
         runtime: [docker, podman]
         version: [1.22.6, 1.17.13, 1.18.10, 1.20.14]
@@ -304,9 +344,21 @@ jobs:
             DISTRIBUTION_SUFFIX=-${{ env.os }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check go agent tools
+        run: |
+          SOFTWARE_MATRIX=go-${{ matrix.version }}
+          AGENT_IMAGE=${{ secrets.DOCKER_USERNAME }}/jenkins-agent-go:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.suffix }}
+          echo "Software Matrix Version: ${SOFTWARE_MATRIX}, Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_software_tools.sh:/tmp/check_agent_software_tools.sh \
+            -e AGENT_IMAGE=$AGENT_IMAGE \
+            -e SOFTWARE_MATRIX=${SOFTWARE_MATRIX} \
+            -i $AGENT_IMAGE /bin/bash -c "
+              ./tmp/check_agent_software_tools.sh
+            "
   build-agent-maven:
     needs: [build-jenkins-agent-base, init-variable]
     strategy:
+      fail-fast: false
       matrix:
         runtime: [docker, podman]
         version: ["8", "11", "17", "21"]
@@ -355,6 +407,17 @@ jobs:
             DISTRIBUTION_SUFFIX=-${{ env.os }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: check maven agent tools
+        run: |
+          SOFTWARE_MATRIX=java-${{ matrix.version }}
+          AGENT_IMAGE=${{ secrets.DOCKER_USERNAME }}/jenkins-agent-maven:${{ needs.init-variable.outputs.container_tag }}${{ steps.step-variable.outputs.suffix }}
+          echo "Software Matrix Version: ${SOFTWARE_MATRIX}, Agent Image: ${AGENT_IMAGE}"
+          docker run -v ./hack/check_agent_software_tools.sh:/tmp/check_agent_software_tools.sh \
+            -e AGENT_IMAGE=$AGENT_IMAGE \
+            -e SOFTWARE_MATRIX=${SOFTWARE_MATRIX} \
+            -i $AGENT_IMAGE /bin/bash -c "
+              ./tmp/check_agent_software_tools.sh
+            "
   validate-relok8s-images:
     needs: [build-jenkins, build-agent-maven, build-agent-golang, build-agent-python, build-agent-nodejs]
     uses: ./.github/workflows/check_relok8s.yaml

--- a/hack/check_agent_base_tools.sh
+++ b/hack/check_agent_base_tools.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+
+executable_tools=(make gcc wget git curl autoconf zip unzip jq vim gettext tree yq argocd kubectl-argo-rollouts kustomize sonar-scanner helm docker kubectl)
+rpm_packages=(gcc-c++ openssl-devel glibc-common)
+dep_packages=(g++ libcurl4-openssl-dev libssl-dev locales)
+count=0
+
+function message() {
+  echo -e "\033[32m$(date '+%Y-%m-%d %H:%M:%S')  $1\033[0m"
+}
+
+function error_message() {
+  echo -e "\033[31m$(date '+%Y-%m-%d %H:%M:%S')  $1\033[0m"
+}
+
+# check the command is executable
+function check_command() {
+  if ! command -v "${1}" &> /dev/null; then
+    error_message "${1} is not executable"
+    count=$((count+1))
+  else
+    message "${1} is executable"
+  fi
+}
+
+# centos: check the package is installed in rpm
+function check_rpm() {
+  if ! rpm -q "${1}" &> /dev/null; then
+    error_message "${1} is not installed in rpm"
+    count=$((count+1))
+  else
+    message "${1} is installed in rpm"
+  fi
+}
+
+# ubuntu: check the package is installed in dep
+function check_dep() {
+  if ! dpkg -l | grep "$1" &> /dev/null; then
+    error_message "$1 package is not installed in dep"
+    count=$((count+1))
+  else
+    message "${1} is installed in dep"
+  fi
+}
+
+main() {
+  for tool in ${executable_tools[*]}; do
+    check_command "${tool}"
+  done
+
+  if [[ "${AGENT_IMAGE}" == *"ubuntu"* ]]; then
+    for package in ${dep_packages[*]}; do
+      check_dep "${package}"
+    done
+  else
+    for package in ${rpm_packages[*]}; do
+      check_rpm "${package}"
+    done
+  fi
+
+  if [ ${count} -ne 0 ]; then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/hack/check_agent_software_tools.sh
+++ b/hack/check_agent_software_tools.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -x
+
+count=0
+
+function message() {
+  echo -e "\033[32m$(date '+%Y-%m-%d %H:%M:%S')  $1\033[0m"
+}
+
+function error_message() {
+  echo -e "\033[31m$(date '+%Y-%m-%d %H:%M:%S')  $1\033[0m"
+}
+
+function check_go_command() {
+  if ! command -v go &> /dev/null; then
+    error_message "go is not executable"
+    count=$((count+1))
+  else
+    message "go is executable"
+  fi
+
+  go_version=$(go version)
+  MATRIX=$(echo "${SOFTWARE_MATRIX}" | sed 's/go-//')
+  if [[ $go_version == *"${MATRIX}"* ]]; then
+    message "go version is right"
+  else
+    error_message "go version is error"
+    count=$((count+1))
+  fi
+}
+
+function check_maven_command() {
+  if ! command -v mvn &> /dev/null; then
+    error_message "mvn is not executable"
+    count=$((count+1))
+  else
+    message "mvn is executable"
+  fi
+}
+
+function check_nodejs_command() {
+  if ! command -v node &> /dev/null; then
+    error_message "node is not executable"
+    count=$((count+1))
+  else
+    message "node is executable"
+  fi
+
+  node_version=$(node --version)
+  MATRIX=$(echo "${SOFTWARE_MATRIX}" | sed 's/nodejs-//')
+  if [[ "${node_version}" == *"${MATRIX}"* ]]; then
+    message "node version is right"
+  else
+    error_message "node version is error"
+    count=$((count+1))
+  fi
+}
+
+function check_python_command() {
+  if ! command -v python &> /dev/null; then
+    error_message "python is not executable"
+    count=$((count+1))
+  else
+    message "python is executable"
+  fi
+
+  if ! command -v pip &> /dev/null; then
+    error_message "pip is not executable"
+    count=$((count+1))
+  else
+    message "pip is executable"
+  fi
+
+  python_version=$(python --version 2>&1)
+  MATRIX=$(echo "${SOFTWARE_MATRIX}" | sed 's/python-//')
+  if [[ "${python_version}" == *"${MATRIX}"* ]]; then
+    message "python version is right"
+  else
+    error_message "python version is error"
+    count=$((count+1))
+  fi
+}
+
+main() {
+  if [[ "${SOFTWARE_MATRIX}" == *"go"* ]]; then
+    check_go_command
+  elif [[ "${SOFTWARE_MATRIX}" == *"java"* ]]; then
+    check_maven_command
+  elif [[ "${SOFTWARE_MATRIX}" == *"python"* ]]; then
+    check_python_command
+  elif [[ "${SOFTWARE_MATRIX}" == *"nodejs"* ]]; then
+    check_nodejs_command
+  fi
+
+  if [ ${count} -ne 0 ]; then
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
这是最新的一次检测结果

- https://github.com/amamba-io/jenkins-agent/actions/runs/11067611288

base 镜像检测工具
- executable_tools=(make gcc wget git curl autoconf zip unzip jq vim gettext tree yq argocd kubectl-argo-rollouts kustomize sonar-scanner helm docker kubectl)
- rpm_packages=(gcc-c++ openssl-devel glibc-common)
- dep_packages=(g++ libcurl4-openssl-dev libssl-dev locales)

go、python、maven、nodejs 目前只检测
- 命令是否可执行
- 版本是否正确